### PR TITLE
Fix loom.attr ns statement to work with newer Clojure

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/loom "0.1.3"
+(defproject cc.artifice/loom "0.1.4"
   :description "Graph library for Clojure"
   :author "Justin Kramer"
   :dependencies [[org.clojure/clojure "1.4.0"]])

--- a/src/loom/attr.clj
+++ b/src/loom/attr.clj
@@ -3,7 +3,7 @@ loom.graph. Common uses for attributes include labels and styling (color,
 thickness, etc)."
       :author "Justin Kramer"}
   loom.attr
-  (use [loom.graph :only [directed? nodes edges]])
+  (:use [loom.graph :only [directed? nodes edges]])
   (:import [loom.graph SimpleGraph SimpleDigraph
             SimpleWeightedGraph SimpleWeightedDigraph
             FlyGraph FlyDigraph WeightedFlyGraph WeightedFlyDigraph]))


### PR DESCRIPTION
Clojure 1.11 disallows (use ...) in an (ns statement); needs to be (:use ...)